### PR TITLE
Added "Weltkindertag" for Thuringia

### DIFF
--- a/src/feiertage.ts
+++ b/src/feiertage.ts
@@ -231,6 +231,7 @@ function getHolidaysOfYear(year: number, region: Region): Holiday[] {
   addReformationstag(year, region, holidays);
   addAllerheiligen(year, region, holidays);
   addBussUndBetttag(year, region, holidays);
+  addWeltkindertag(year, region, holidays);
 
   return holidays.sort(
     (a: Holiday, b: Holiday) => a.date.getTime() - b.date.getTime(),
@@ -361,6 +362,16 @@ function addBussUndBetttag(
         ),
       ),
     );
+  }
+}
+
+function addWeltkindertag(
+  year: number,
+  region: Region,
+  holidays: Holiday[],
+): void {
+  if (year >= 2019 && (region === 'TH' || region === 'ALL')) {
+    holidays.push(newHoliday('WELTKINDERTAG', makeDate(year, 9, 20)));
   }
 }
 

--- a/src/german-translations.ts
+++ b/src/german-translations.ts
@@ -18,4 +18,5 @@ export const germanTranslations: TranslationTable = {
   BUBETAG: 'Buß- und Bettag',
   ERSTERWEIHNACHTSFEIERTAG: '1. Weihnachtstag',
   ZWEITERWEIHNACHTSFEIERTAG: '2. Weihnachtstag',
+  WELTKINDERTAG: 'Weltkindertag',
 };

--- a/src/holiday-type.ts
+++ b/src/holiday-type.ts
@@ -15,7 +15,8 @@ export type HolidayType =
   | 'ALLERHEILIGEN'
   | 'BUBETAG'
   | 'ERSTERWEIHNACHTSFEIERTAG'
-  | 'ZWEITERWEIHNACHTSFEIERTAG';
+  | 'ZWEITERWEIHNACHTSFEIERTAG'
+  | 'WELTKINDERTAG';
 
 export const allHolidays: HolidayType[] = [
   'NEUJAHRSTAG',
@@ -35,4 +36,5 @@ export const allHolidays: HolidayType[] = [
   'BUBETAG',
   'ERSTERWEIHNACHTSFEIERTAG',
   'ZWEITERWEIHNACHTSFEIERTAG',
+  'WELTKINDERTAG',
 ];


### PR DESCRIPTION
From 2019 the "Weltkindertag" will be holiday in Thuringia.

Source:
https://www.welt.de/newsticker/dpa_nt/infoline_nt/brennpunkte_nt/article181687092/Thueringen-macht-Weltkindertag-zum-gesetzlichen-Feiertag.html