### PR TITLE
Drop node 6 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ language: node_js
 node_js:
     - "10"
     - "8"
-    - "6"
 # keep the npm cache around to speed up installs
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 language: node_js
 node_js:
-    - "10"
-    - "8"
+  - "11
+  - "10"
+  - "8"
 # keep the npm cache around to speed up installs
 cache:
   directories:

--- a/package.json
+++ b/package.json
@@ -22,6 +22,9 @@
     "feiertage",
     "javascript"
   ],
+  "engines": {
+    "node": ">=8.0.0"
+  },
   "author": "Simon Fakir",
   "license": "MIT",
   "bugs": {


### PR DESCRIPTION
The support for Node 6 will be dropped [April 30, 2019](https://github.com/nodejs/Release). This PR removes Node 6 from the CI config and replaces it with Node 11