### PR TITLE
Add: Unit tests for feiertage.ts#137,154

### DIFF
--- a/spec/errors.spec.ts
+++ b/spec/errors.spec.ts
@@ -5,11 +5,23 @@ describe('Throw errors:', () => {
     // $FlowFixMe: test wrong region arg
     expect(() => isHoliday(new Date(), 'SWISS' as any)).toThrowError();
   });
+  it('should throw an undefined Region error', () => {
+    expect(() => isHoliday(new Date(), undefined as any)).toThrowError();
+  });
+  it('should throw an null Region error', () => {
+    expect(() => isHoliday(new Date(), null as any)).toThrowError();
+  });
   it('should throw an invalid holiday error', () => {
     // $FlowFixMe: test wrong holiday arg
-    expect(() => isSpecificHoliday(new Date(), 'RANDOM' as any)).toThrowError(
-      Error,
-    );
+    expect(() => isSpecificHoliday(new Date(), 'RANDOM' as any)).toThrowError();
+  });
+  it('should throw an undefined Holiday error', () => {
+    expect(() =>
+      isSpecificHoliday(new Date(), undefined as any),
+    ).toThrowError();
+  });
+  it('should throw an null Holiday error', () => {
+    expect(() => isSpecificHoliday(new Date(), null as any)).toThrowError();
   });
 
   it('New Year should be a holiday', () => {

--- a/spec/feiertage.spec.ts
+++ b/spec/feiertage.spec.ts
@@ -35,7 +35,7 @@ describe('Holidays 2015 in Bavaria:', () => {
     expect(isSunOrHoliday(sunday, 'BY')).toBe(false);
   });
 
-  it('Christmas  to be a holiday', () => {
+  it('Christmas to be a holiday', () => {
     const christmas1 = new Date(2015, 11, 25);
     expect(isHoliday(christmas1, 'BY')).toEqual(true);
 

--- a/spec/feiertage2019.spec.ts
+++ b/spec/feiertage2019.spec.ts
@@ -1,16 +1,14 @@
 // https://de.wikipedia.org/wiki/Feiertage_in_Deutschland
 
-import {
-  getHolidayByDate,
-} from '../src/feiertage';
+import { getHolidayByDate } from '../src/feiertage';
 
 /**
  * Test for this comment https://github.com/sfakir/feiertagejs/commit/fefa9958b7105df9f7f964d27661bc775995871b
  */
 describe('get Specific holiday by Date', () => {
   it('find WELTKINDERTAG 2019', () => {
-    const weltkindertab = new Date(2020, 8, 20);
-    expect(getHolidayByDate(weltkindertab, 'TH')).toEqual(
+    const weltkindertag = new Date(2020, 8, 20);
+    expect(getHolidayByDate(weltkindertag, 'TH')).toEqual(
       expect.objectContaining({
         name: 'WELTKINDERTAG',
       }),
@@ -27,18 +25,14 @@ describe('get Specific holiday by Date', () => {
   });
   it('find Weltfrauentag >2019 8th or March should not be a holiday in BY', () => {
     const WELTFRAUENTAG = new Date(2020, 2, 8);
-    expect(getHolidayByDate(WELTFRAUENTAG, 'BY')).toEqual(undefined );
+    expect(getHolidayByDate(WELTFRAUENTAG, 'BY')).toEqual(undefined);
   });
   it('find Weltfrauentag <2019 should not be a holiday in Berlin', () => {
     const WELTFRAUENTAG = new Date(2016, 2, 8);
-    expect(getHolidayByDate(WELTFRAUENTAG, 'BE')).toEqual(
-      undefined
-    );
+    expect(getHolidayByDate(WELTFRAUENTAG, 'BE')).toEqual(undefined);
   });
   it('find Weltfrauentag <2019 should not be a holiday in BW', () => {
     const WELTFRAUENTAG = new Date(2016, 2, 8);
-    expect(getHolidayByDate(WELTFRAUENTAG, 'BW')).toEqual(
-      undefined
-    );
+    expect(getHolidayByDate(WELTFRAUENTAG, 'BW')).toEqual(undefined);
   });
 });


### PR DESCRIPTION
Those lines have been untested before, so why not add some tests for this.

Testing if the `region` argument is `null` or `undefined` in `isHoliday` and if `holidayName` in `isSpecificHoliday` matches those criteria.