### PR TITLE
fix: maria himmelfahrt should be a holiday if region is set to ALL

### DIFF
--- a/spec/feiertage.spec.ts
+++ b/spec/feiertage.spec.ts
@@ -50,6 +50,13 @@ describe('Holidays 2016 in BW:', () => {
   });
 });
 
+describe('Holidays ALL', () => {
+  it('Mariae Himmelfahrt should be a holiday if region type is set to ALL', () => {
+    const himmelfahrt = new Date(2022, 8, 15)
+    expect(isHoliday(himmelfahrt, 'ALL')).toBe(true)
+  })
+})
+
 describe('Holidays 2016 in NW:', () => {
   it('Heilige Drei Könige should not be available', () => {
     const result = getHolidays(2016, 'NW');

--- a/src/feiertage.ts
+++ b/src/feiertage.ts
@@ -323,7 +323,7 @@ function addMariaeHimmelfahrt(
   region: Region,
   holidays: Holiday[],
 ): void {
-  if (region === 'SL' || region === 'BY' || region === 'AUGSBURG') {
+  if (region === 'SL' || region === 'BY' || region === 'AUGSBURG' || region === 'ALL') {
     holidays.push(newHoliday('MARIAHIMMELFAHRT', makeDate(year, 8, 15)));
   }
 }


### PR DESCRIPTION
Maria Himmelfahrt should also be added to the holidays array if the region type is set to "ALL" as in this case you want all the holidays to be included