### PR TITLE
fix: fix german timestamp calculation that expects 0 milliseconds

### DIFF
--- a/spec/germanTimezone.spec.ts
+++ b/spec/germanTimezone.spec.ts
@@ -3,7 +3,7 @@
 // regardless of the server's timezone setting.
 
 import { describe, it, expect } from 'vitest';
-import { isHoliday, getHolidayByDate } from '../src/feiertage';
+import { isHoliday, getHolidayByDate, isSpecificHoliday } from '../src/feiertage';
 
 describe('German timezone conversion', () => {
   /**
@@ -178,4 +178,13 @@ describe('German timezone conversion', () => {
       expect(holiday?.name).toBe('ERSTERWEIHNACHTSFEIERTAG');
     });
   });
+
+  describe('Dates created with milliseconds', () => {
+   it('should recognize UTC date "2025-05-28T23:00:00.500Z" as holiday even with non-zero milliseconds', () => {
+    const date = new Date('2025-05-28T23:00:00.500Z');
+    expect(isHoliday(date, 'ALL')).toBe(true);
+    expect(isSpecificHoliday(date, 'CHRISTIHIMMELFAHRT', 'ALL')).toBe(true);
+    });
+  });
+
 });

--- a/src/feiertage.ts
+++ b/src/feiertage.ts
@@ -709,8 +709,8 @@ function toGermanTimezoneTimestamp(date: Date): number {
       const second = parseInt(secondPart.value, 10);
       if (!Number.isNaN(hour) && !Number.isNaN(minute) && !Number.isNaN(second)) {
         const millisecondsFromMidnight =
-          hour * 3600 * 1000 + minute * 60 * 1000 + second * 1000;
-        const result = date.getTime() - millisecondsFromMidnight;
+          hour * 3600 * 1000 + minute * 60 * 1000 + second * 1000;        
+        const result = new Date(date).setMilliseconds(0) - millisecondsFromMidnight;
         const fallback = toGermanTimezoneTimestampFallback(date);
         if (Math.abs(result - fallback) < 60000) return result;
       }


### PR DESCRIPTION
The function isHoliday can't handle non zero millisecond dates at the moment. The reason for that is because the german timestamp calculation doesn't consider milliseconds from input dates. That causes subsequent holiday calculations to fail that use the german timestamp as index.

You can reproduce the error by running the following code in the node repl:

```
const { isHoliday } = await import("feiertagejs");

> isHoliday(new Date('2023-05-01T10:00:00.000Z'),'ALL')
true
> isHoliday(new Date('2023-05-01T10:00:00.111Z'),'ALL')
false

``` 

The most simple solution would be to "normalize" the input date during the german timestamp calculation by setting the input dates milliseconds to 0. 

But maybe it does make sense to extend the timestamp calculation, to also consider milliseconds, since we are essentially representing the "milliseconds since epoch" with that calculation.



